### PR TITLE
[fix] standardize schema to use pubDate across all collections

### DIFF
--- a/src/components/SlidesList.astro
+++ b/src/components/SlidesList.astro
@@ -10,9 +10,9 @@ const visible = slides.length > 0
     <h2 class="text-2xl">Slides</h2>
     { visible ? <ul class="mt-4">
       {slides.map((slide) => <li class="flex flex-wrap items-center gap-x-2">
-        <time {new Date(slide.data.date.toDateString())} class="min-w-[120px] text-gray-500">{slide.data.date.toDateString()}</time>
+        <time {new Date(slide.data.pubDate.toDateString())} class="min-w-[120px] text-gray-500">{slide.data.pubDate.toDateString()}</time>
         
-        <a href={"/slides/" + slide.slug} class="inline-block cactus-link line-clamp-1 hover:underline">{slide.data.title}</a>
+        <a href={"/slides/" + slide.id} class="inline-block cactus-link line-clamp-1 hover:underline">{slide.data.title}</a>
         
         </li>)}
     </ul>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -29,7 +29,7 @@ const slidesCollection = defineCollection({
   }),
   schema: z.object({
     title: z.string(),
-    date: z.date(),
+    pubDate: z.coerce.date(),
     description: z.string(),
     draft: z.boolean().optional()
   })

--- a/src/content/slides/graphql-intro.md
+++ b/src/content/slides/graphql-intro.md
@@ -1,7 +1,7 @@
 ---
 title: Graphql introduction
 description: Introduction to Graphql and Spring Boot support.
-date: 2023-07-01
+pubDate: 2023-07-01
 draft: false
 ---
 

--- a/src/content/slides/local-llm.md
+++ b/src/content/slides/local-llm.md
@@ -1,7 +1,7 @@
 ---
 title: Local LLM
 description: Running Local Code LLM for no profit.
-date: 2024-02-12
+pubDate: 2024-02-12
 draft: true
 ---
 

--- a/src/content/slides/test.md
+++ b/src/content/slides/test.md
@@ -1,7 +1,7 @@
 ---
 title: Using ressources
 description: test lecture for reference.
-date: 2022-07-01
+pubDate: 2022-07-01
 draft: true
 ---
 ## Handling resources with Use


### PR DESCRIPTION
- Change slides collection schema from 'date' to 'pubDate' to match posts
- Update all slide markdown files to use 'pubDate' instead of 'date'
- Fix SlidesList component to use slide.data.pubDate and slide.id
- Ensures consistent date handling across posts and slides collections
- Fixes potential undefined slug issues in slides similar to posts

---🤖 Generated with https://claude.ai/code