### PR TITLE
[fix] repair RSS feed links and add missing attributes

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -20,18 +20,17 @@ export async function GET(context) {
 			dc: "http://purl.org/dc/elements/1.1/",
 			atom: "http://www.w3.org/2005/Atom"
 		},
-		// stylesheet: '/rss/styles.xsl',
+		stylesheet: '/rss/styles.xsl',
 		items: posts.map((post) => ({
 			title: post.data.title,
 			pubDate: post.data.pubDate,
 			description: post.data.description,
-			// todo probably should automate this as it may break in the future.
-			link: `/blog/posts/${post.slug}/`,
+			link: `/posts/${post.id}/`,
 			content: sanitizeHtml(parser.render(post.body)),
 			customData: "<dc:creator><![CDATA[Vincent S.-G.]]></dc:creator>"
 		})),
 		customData: `<lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
-		<atom:link href="${new URL("rss.xml", context.site)}" rel="self" type="application/rss+xml" />`
-		// todo add post language
+		<atom:link href="${new URL("rss.xml", context.site)}" rel="self" type="application/rss+xml" />
+		<language>en</language>`
 	});
 }


### PR DESCRIPTION
## Summary
- Fix broken RSS feed links from `/blog/posts/undefined/` to `/posts/{id}/`
- Change `post.slug` to `post.id` to resolve undefined references in Content Layer API
- Enable RSS stylesheet for better feed presentation
- Add `language='en'` attribute for proper RSS compliance

## Issues Fixed
🚨 **Critical**: RSS feed links were completely broken, pointing to `/blog/posts/undefined/`
⚠️ **Medium**: Missing language metadata and disabled stylesheet
🔧 **Minor**: Outdated TODO comments removed

## Test plan
- [x] Build generates valid RSS XML
- [x] Links now point to correct `/posts/{slug}/` URLs  
- [x] RSS validates with proper language and stylesheet attributes
- [x] Feed content renders correctly with full post content

🤖 Generated with [Claude Code](https://claude.ai/code)