### PR TITLE
[style] simplify site design inspired by sunilpai.dev

### DIFF
--- a/src/components/BlogList.astro
+++ b/src/components/BlogList.astro
@@ -11,7 +11,7 @@ const notes = await getCollection("notes", ({ data }) =>
   isDev ? true : data.draft !== true
 );
 
-type FeedPost = { kind: "post"; id: string; pubDate: Date; title: string };
+type FeedPost = { kind: "post"; id: string; pubDate: Date; title: string; description?: string };
 type FeedNote = {
   kind: "note";
   id: string;
@@ -30,6 +30,7 @@ const feed: FeedItem[] = [
     id: p.id,
     pubDate: p.data.pubDate,
     title: p.data.title,
+    description: p.data.description,
   })),
   ...notes.map((n) => ({
     kind: "note" as const,
@@ -47,43 +48,45 @@ const formatDate = (d: Date) =>
   d.toLocaleDateString("en-ca", { year: "numeric", month: "short", day: "numeric" });
 ---
 
-<div class="mx-auto max-w-screen-lg px-3 py-6">
-  <h2 class="text-2xl">Posts & Notes</h2>
+<div class="mx-auto max-w-2xl px-4 py-4">
+  <h2 class="text-lg font-semibold mb-6">Posts</h2>
   {feed.length === 0 ? (
-    <p class="mt-4 text-gray-200">Coming Soon!</p>
+    <p class="text-gray-500">Coming Soon!</p>
   ) : (
-    <ul class="mt-4 space-y-4">
+    <ul class="space-y-5">
       {feed.map((item) => (
         <li>
           {item.kind === "post" && (
-            <div class="flex flex-wrap items-center gap-x-2">
-              <time
-                datetime={item.pubDate.toISOString()}
-                class="min-w-[120px] text-gray-500"
-              >
-                {formatDate(item.pubDate)}
-              </time>
-              <a
-                href={"/posts/" + item.id}
-                class="inline-block cactus-link line-clamp-1 hover:underline"
-              >
-                {item.title}
-              </a>
+            <div>
+              <div class="flex items-baseline gap-x-6">
+                <time
+                  datetime={item.pubDate.toISOString()}
+                  class="text-sm text-gray-500 shrink-0 w-28"
+                >
+                  {formatDate(item.pubDate)}
+                </time>
+                <a href={"/posts/" + item.id} class="hover:underline text-gray-100">
+                  {item.title}
+                </a>
+              </div>
+              {item.description && (
+                <p class="mt-0.5 ml-[136px] text-sm italic text-gray-500">"{item.description}"</p>
+              )}
             </div>
           )}
 
           {item.kind === "note" && item.type === "link" && (
             <div>
-              <div class="flex flex-wrap items-center gap-x-2">
+              <div class="flex items-baseline gap-x-6">
                 <time
                   datetime={item.pubDate.toISOString()}
-                  class="min-w-[120px] text-gray-500 text-sm"
+                  class="text-sm text-gray-500 shrink-0 w-28"
                 >
                   {formatDate(item.pubDate)}
                 </time>
                 <a
                   href={item.url}
-                  class="inline-block cactus-link hover:underline font-medium"
+                  class="hover:underline text-gray-100"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -91,37 +94,37 @@ const formatDate = (d: Date) =>
                 </a>
               </div>
               {item.body && (
-                <p class="mt-1 ml-[128px] text-sm text-gray-400">{item.body.trim()}</p>
+                <p class="mt-0.5 ml-[136px] text-sm italic text-gray-500">{item.body.trim()}</p>
               )}
             </div>
           )}
 
           {item.kind === "note" && item.type === "quote" && (
-            <div>
+            <div class="flex items-baseline gap-x-6">
               <time
                 datetime={item.pubDate.toISOString()}
-                class="text-gray-500 text-sm"
+                class="text-sm text-gray-500 shrink-0 w-28"
               >
                 {formatDate(item.pubDate)}
               </time>
-              <blockquote class="mt-1 border-l-2 border-gray-500 pl-4 italic text-gray-300">
+              <blockquote class="border-l-2 border-gray-600 pl-3 italic text-gray-400 text-sm">
                 {item.quote ?? item.body.trim()}
                 {item.source && (
-                  <footer class="mt-1 text-sm not-italic text-gray-500">— {item.source}</footer>
+                  <footer class="mt-0.5 not-italic text-gray-500">— {item.source}</footer>
                 )}
               </blockquote>
             </div>
           )}
 
           {item.kind === "note" && item.type === "note" && (
-            <div>
+            <div class="flex items-baseline gap-x-6">
               <time
                 datetime={item.pubDate.toISOString()}
-                class="text-gray-500 text-sm"
+                class="text-sm text-gray-500 shrink-0 w-28"
               >
                 {formatDate(item.pubDate)}
               </time>
-              <p class="mt-1 text-gray-300 text-sm">{item.body.trim()}</p>
+              <p class="text-sm text-gray-300">{item.body.trim()}</p>
             </div>
           )}
         </li>

--- a/src/components/BlogList.astro
+++ b/src/components/BlogList.astro
@@ -44,91 +44,84 @@ const feed: FeedItem[] = [
   })),
 ].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
 
-const formatDate = (d: Date) =>
-  d.toLocaleDateString("en-ca", { year: "numeric", month: "short", day: "numeric" });
+// Group feed items by date (YYYY-MM-DD)
+const grouped = feed.reduce<{ date: string; displayDate: string; items: FeedItem[] }[]>(
+  (acc, item) => {
+    const key = item.pubDate.toISOString().slice(0, 10);
+    const display = item.pubDate.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    const group = acc.find((g) => g.date === key);
+    if (group) {
+      group.items.push(item);
+    } else {
+      acc.push({ date: key, displayDate: display, items: [item] });
+    }
+    return acc;
+  },
+  []
+);
 ---
 
 <div class="mx-auto max-w-2xl px-4 py-4">
-  <h2 class="text-lg font-semibold mb-6">Posts</h2>
-  {feed.length === 0 ? (
+  {grouped.length === 0 ? (
     <p class="text-gray-500">Coming Soon!</p>
   ) : (
-    <ul class="space-y-5">
-      {feed.map((item) => (
-        <li>
-          {item.kind === "post" && (
-            <div>
-              <div class="flex items-baseline gap-x-6">
-                <time
-                  datetime={item.pubDate.toISOString()}
-                  class="text-sm text-gray-500 shrink-0 w-28"
-                >
-                  {formatDate(item.pubDate)}
-                </time>
-                <a href={"/posts/" + item.id} class="hover:underline text-gray-100">
-                  {item.title}
-                </a>
-              </div>
-              {item.description && (
-                <p class="mt-0.5 ml-[136px] text-sm italic text-gray-500">"{item.description}"</p>
-              )}
-            </div>
-          )}
-
-          {item.kind === "note" && item.type === "link" && (
-            <div>
-              <div class="flex items-baseline gap-x-6">
-                <time
-                  datetime={item.pubDate.toISOString()}
-                  class="text-sm text-gray-500 shrink-0 w-28"
-                >
-                  {formatDate(item.pubDate)}
-                </time>
-                <a
-                  href={item.url}
-                  class="hover:underline text-gray-100"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  → {item.source ?? item.url}
-                </a>
-              </div>
-              {item.body && (
-                <p class="mt-0.5 ml-[136px] text-sm italic text-gray-500">{item.body.trim()}</p>
-              )}
-            </div>
-          )}
-
-          {item.kind === "note" && item.type === "quote" && (
-            <div class="flex items-baseline gap-x-6">
-              <time
-                datetime={item.pubDate.toISOString()}
-                class="text-sm text-gray-500 shrink-0 w-28"
-              >
-                {formatDate(item.pubDate)}
-              </time>
-              <blockquote class="border-l-2 border-gray-600 pl-3 italic text-gray-400 text-sm">
-                {item.quote ?? item.body.trim()}
-                {item.source && (
-                  <footer class="mt-0.5 not-italic text-gray-500">— {item.source}</footer>
+    <div class="space-y-10">
+      {grouped.map(({ displayDate, items }) => (
+        <section>
+          <h2 class="text-sm font-semibold text-gray-500 mb-4 uppercase tracking-wide">
+            {displayDate}
+          </h2>
+          <ul class="space-y-5">
+            {items.map((item) => (
+              <li>
+                {item.kind === "post" && (
+                  <div>
+                    <a href={"/posts/" + item.id} class="hover:underline font-medium text-gray-100">
+                      {item.title}
+                    </a>
+                    {item.description && (
+                      <p class="mt-1 text-sm italic text-gray-500">"{item.description}"</p>
+                    )}
+                  </div>
                 )}
-              </blockquote>
-            </div>
-          )}
 
-          {item.kind === "note" && item.type === "note" && (
-            <div class="flex items-baseline gap-x-6">
-              <time
-                datetime={item.pubDate.toISOString()}
-                class="text-sm text-gray-500 shrink-0 w-28"
-              >
-                {formatDate(item.pubDate)}
-              </time>
-              <p class="text-sm text-gray-300">{item.body.trim()}</p>
-            </div>
-          )}
-        </li>
+                {item.kind === "note" && item.type === "link" && (
+                  <div>
+                    <a
+                      href={item.url}
+                      class="hover:underline font-medium text-gray-100"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      → {item.source ?? item.url}
+                    </a>
+                    {item.body && (
+                      <p class="mt-1 text-sm text-gray-400">{item.body.trim()}</p>
+                    )}
+                  </div>
+                )}
+
+                {item.kind === "note" && item.type === "quote" && (
+                  <blockquote class="border-l-2 border-gray-600 pl-4 space-y-1">
+                    <p class="italic text-gray-300">{item.quote ?? item.body.trim()}</p>
+                    {item.source && (
+                      <footer class="text-sm text-gray-500">— {item.source}</footer>
+                    )}
+                  </blockquote>
+                )}
+
+                {item.kind === "note" && item.type === "note" && (
+                  <p class="text-sm text-gray-400">{item.body.trim()}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
       ))}
-    </ul>
+    </div>
   )}
 </div>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -1,48 +1,16 @@
 ---
-import { Icon } from "astro-icon/components";
-import Section from "./Section.astro";
-console.log(import.meta.env.SITE);
-
 ---
 
-<Section>
-    <nav>
-      <ul class="flex flex-row gap-y-3 my-2 flex-wrap items-center gap-x-5 font-medium text-gray-200">
-        <li class="grow">
-          <a href="/">◣</a>
-        </li>
-        <li>
-          <a class="hover:underline hover:text-purple-400" href="/posts/uses"
-            >Uses</a>
-        </li>
-        <li>
-          <a href="https://github.com/vinsg"
-            ><Icon
-              name={"ion:logo-github"}
-              class="fill-white h-6 w-6 hover:text-purple-400"
-            /></a>
-        </li>
-        <li>
-          <a href="mailto:contact@vinsg.ca"
-            ><Icon
-              name={"ion:email"}
-              class="fill-white h-6 w-6 hover:text-purple-400"
-            /></a>
-        </li>
-        <li>
-          <a href="https://x.com/vinsg_"
-            ><Icon
-              name={"ion:logo-x"}
-              class="fill-white h-5 w-5 hover:text-purple-400"
-            /></a>
-        </li>
-        <li>
-          <a href={new URL("rss.xml", Astro.site)}
-            ><Icon
-              name={"ion:logo-rss"}
-              class="fill-white h-6 w-6 hover:text-purple-400"
-            /></a>
-        </li>
-      </ul>
-    </nav>
-</Section>
+<header class="mx-auto max-w-2xl px-4 py-6">
+  <nav class="flex items-center gap-x-6">
+    <a href="/" class="flex items-center gap-x-2 font-semibold text-gray-100 no-underline">
+      <span class="text-xl">◣</span>
+      <span>vinsg</span>
+    </a>
+    <span class="text-gray-600">|</span>
+    <a href="/" class="text-gray-400 hover:text-gray-100 text-sm">Home</a>
+    <a href="/posts/uses" class="text-gray-400 hover:text-gray-100 text-sm">Uses</a>
+    <a href="https://github.com/vinsg" class="text-gray-400 hover:text-gray-100 text-sm">GitHub</a>
+    <a href="/rss.xml" class="text-gray-400 hover:text-gray-100 text-sm">RSS</a>
+  </nav>
+</header>

--- a/src/components/Section.astro
+++ b/src/components/Section.astro
@@ -1,3 +1,3 @@
-<div class="mx-auto max-w-screen-lg px-3 py-6">
+<div class="mx-auto max-w-2xl px-4 py-4">
     <slot></slot>
 </div>

--- a/src/layouts/BaseBlog.astro
+++ b/src/layouts/BaseBlog.astro
@@ -14,42 +14,37 @@ const { frontmatter, slug, readingTime } = Astro.props;
       image={`${import.meta.env.SITE}/posts/${slug}/og.png`}
     />
     <meta property="og:type" content="article" />
-
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={frontmatter.title} />
     <meta property="twitter:description" content={frontmatter.description} />
-    <meta
-      name="twitter:image"
-      content={`${import.meta.env.SITE}/posts/${slug}/og.png`}
-    />
+    <meta name="twitter:image" content={`${import.meta.env.SITE}/posts/${slug}/og.png`} />
   </head>
 
   <body class="bg-slate-900 text-gray-100">
     <NavBar />
-    <div class="max-w-prose mx-auto px-3 py-6 space-y-10">
-      <p class="text-center text-xl uppercase font-bold text-gray-400">
-        {
-          frontmatter.pubDate.toLocaleDateString("en-US", {
+    <main class="mx-auto max-w-2xl px-4 py-8">
+      <div class="mb-8">
+        <p class="text-sm text-gray-500 mb-2">
+          {frontmatter.pubDate.toLocaleDateString("en-US", {
             year: "numeric",
             month: "long",
             day: "numeric",
-          })
-        } ~ {readingTime}
-      </p>
-      <h1 class="text-center text-6xl font-bold">{frontmatter.title}</h1>
+          })}
+          {readingTime && <span> · {readingTime}</span>}
+        </p>
+        <h1 class="text-3xl font-bold">{frontmatter.title}</h1>
+        {frontmatter.description && (
+          <p class="mt-2 italic text-gray-400">"{frontmatter.description}"</p>
+        )}
+      </div>
 
-      <hr
-        class="p-0 border-0 h-[10px] my-[40px] w-1/2 center mx-auto"
-        style="background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg width=%2720%27 height=%2710%27 viewBox=%270%200%2020%2010%27 xmlns=%27http://www.w3.org/2000/svg%27 fill-rule=%27evenodd%27 clip-rule=%27evenodd%27 stroke-miterlimit=%2710%27%3e%3cpath fill=%27none%27 d=%27M0%200h20v10H0z%27/%3e%3cclipPath id=%27a%27%3e%3cpath d=%27M0%200h20v10H0z%27/%3e%3c/clipPath%3e%3cg clip-path=%27url(%23a)%27%3e%3cpath d=%27M20%207.384c-4.999-.001-5-4.768-9.999-4.768C5%202.616%205%207.384%200%207.384%27 fill=%27none%27 stroke-width=%273%27 stroke=%27%23548E9B%27/%3e%3c/g%3e%3c/svg%3e'); background-position: center;"
-      />
-
-      <div class="prose prose-invert mt-8 prose-img:rounded-lg">
+      <div class="prose prose-invert prose-img:rounded-lg max-w-none">
         <slot />
       </div>
-      <hr>
-      <p class="text-center mx-auto pb-10">
-        by <a  href=https://x.com/vinsg_>@vinsg_</a>
-      </p>
-    </div>
+
+      <footer class="mt-12 pt-6 border-t border-gray-800 text-sm text-gray-500">
+        by <a href="https://x.com/vinsg_" class="hover:underline">@vinsg_</a>
+      </footer>
+    </main>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,6 @@
 ---
 import Base from "../layouts/Base.astro";
 import BlogList from "../components/BlogList.astro";
-import Hero from "../components/Hero.astro";
-import ProjectList from "../components/ProjectList.astro";
-import SlidesList from "../components/SlidesList.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 ---
 
@@ -11,8 +8,5 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
   title={SITE_TITLE}
   description={SITE_DESCRIPTION}
 >
-  <Hero />
   <BlogList />
-  <!-- <SlidesList />
-  <ProjectList /> -->
 </Base>


### PR DESCRIPTION
- Remove Hero section; homepage goes straight to post list
- Replace icon-heavy NavBar with plain text links (name | Home | Uses | GitHub | RSS)
- Simplify BlogList to two-column date/title layout with italic descriptions
- Narrow max-width from screen-lg to 2xl for tighter, focused layout
- Simplify Section wrapper padding
- Clean up BaseBlog post header: remove wavy divider, simpler date/title/description display

---🤖 Generated with https://claude.ai/code