### PR TITLE
[build] update dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,29 +10,29 @@
     "astro": "astro"
   },
   "devDependencies": {
-    "@astrojs/react": "^4.4.2",
+    "@astrojs/react": "^5.0.0",
     "@astrojs/tailwind": "^6.0.2",
     "@catppuccin/highlightjs": "^1.0.1",
     "@tailwindcss/typography": "^0.5.19",
     "@types/reveal.js": "^5.2.2",
-    "@types/sanitize-html": "^2.16.0",
-    "astro": "^5.17.3",
+    "@types/sanitize-html": "^2.16.1",
+    "astro": "^6.0.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "dependencies": {
-    "@astrojs/rss": "^4.0.15",
-    "@astrojs/sitemap": "^3.7.0",
-    "@iconify-json/ion": "^1.2.6",
+    "@astrojs/rss": "^4.0.17",
+    "@astrojs/sitemap": "^3.7.1",
+    "@iconify-json/ion": "^1.2.7",
     "@iconify-json/ri": "^1.2.10",
     "@resvg/resvg-js": "^2.6.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vercel/og": "^0.8.6",
+    "@vercel/og": "^0.11.1",
     "astro-icon": "^1.1.5",
     "markdown-it": "^14.1.1",
     "reading-time": "^1.5.0",
-    "reveal.js": "^5.2.1",
+    "reveal.js": "^6.0.0",
     "sanitize-html": "^2.17.1"
   }
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,11 +18,11 @@ const { title } = Astro.props;
     <slot />
     <script>
       import Reveal from "reveal.js";
-      import RevealMarkdown from "reveal.js/plugin/markdown/markdown.js";
-      import RevealHighlight from "reveal.js/plugin/highlight/highlight.js";
-      import RevealZoom from "reveal.js/plugin/zoom/zoom.js";
-      import RevealNotes from "reveal.js/plugin/notes/notes.js";
-      import RevealMath from "reveal.js/plugin/math/math.js";
+      import RevealMarkdown from "reveal.js/plugin/markdown";
+      import RevealHighlight from "reveal.js/plugin/highlight";
+      import RevealZoom from "reveal.js/plugin/zoom";
+      import RevealNotes from "reveal.js/plugin/notes";
+      import RevealMath from "reveal.js/plugin/math";
 
 
       Reveal.initialize({
@@ -44,7 +44,7 @@ const { title } = Astro.props;
 </html>
 
 <style is:global>
-  @import "reveal.js/dist/reveal.css";
-  @import "reveal.js/dist/theme/dracula.css";
+  @import "reveal.js/reveal.css";
+  @import "reveal.js/theme/dracula.css";
   @import "@catppuccin/highlightjs/css/catppuccin-mocha.css";
 </style>


### PR DESCRIPTION
Update all packages to their latest versions including major bumps for
astro (5→6), @astrojs/react (4→5), reveal.js (5→6), and @vercel/og
(0.8→0.11). Fix reveal.js v6 breaking changes: update CSS imports from
dist/ paths to package-level exports, and update plugin imports to use
the new export map specifiers.

---🤖 Generated with https://claude.ai/code